### PR TITLE
WR441709: Fix unit test failure caused by core_calendar

### DIFF
--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -42,8 +42,8 @@ class mod_adaptivequiz_generator extends testing_module_generator {
         $record = (object)(array)$record;
 
         if (!isset($record->questionpool) && !isset($record->questionpoolnamed)) {
-            throw new coding_exception('either \'questionpool\' or \'questionpoolnamed\' property must be specified when '.
-                'generating an adaptive quiz instance');
+            $defaultpoolid = $this->get_default_question_pool_id();
+            $record->questionpool = $defaultpoolid;
         }
 
         // Named question pool takes precedence over the 'questionpool' setting.
@@ -81,6 +81,11 @@ class mod_adaptivequiz_generator extends testing_module_generator {
         }
 
         return parent::create_instance($record, $options);
+    }
+
+    private function get_default_question_pool_id() {
+        global $DB;
+        return $DB->get_field('question_categories', 'id', ['contextid' => 1]);
     }
 
     /**


### PR DESCRIPTION
```
1) core_calendar\container_test::test_delete_module_delete_events
coding_exception: Coding error detected, it must be fixed by a programmer: either 'questionpool' or 'questionpoolnamed' property must be specified when generating an adaptive quiz instance

/var/www/site/mod/adaptivequiz/tests/generator/lib.php:45
/var/www/site/calendar/tests/container_test.php:476
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
```